### PR TITLE
Register CalendarCalendarEvent join table in SetupDatabase

### DIFF
--- a/database.go
+++ b/database.go
@@ -166,6 +166,14 @@ func SetupDatabase(dbHost, dbUser, dbPassword, dbName string) (*gorm.DB, error) 
 		return nil, err
 	}
 
+	// Register CalendarCalendarEvent as the join model for Calendar.Events.
+	// Without this, GORM treats calendar_calendar_events as a plain many2many
+	// join table and AutoMigrate silently skips the struct's extra columns
+	// (featured, members_only, tier_ids_only).
+	if err := db.SetupJoinTable(&Calendar{}, "Events", &CalendarCalendarEvent{}); err != nil {
+		return nil, err
+	}
+
 	sqlDB, err := db.DB()
 	if err != nil {
 		log.Fatalf("failed to get sqlDB: %v", err)


### PR DESCRIPTION
## Problem

`Calendar.Events` declares `many2many:calendar_calendar_events`, while `CalendarCalendarEvent` is a custom struct with extra columns (`featured`, `members_only`, `tier_ids_only`). Because the join model is never registered, GORM treats the table as a plain two-column join table and `AutoMigrate(CalendarCalendarEvent{})` returns OK without creating those columns.

On any freshly migrated database (e.g. local setup via the api repo's `make migrate_schemas`), every calendar event visibility/featured query then fails with `column does not exist`. Dev/prod are unaffected — their columns already exist.

## Fix

Call `db.SetupJoinTable(&Calendar{}, "Events", &CalendarCalendarEvent{})` in `SetupDatabase`, so every consumer that migrates through this package gets the full join model. Checked all other `many2many` tags in the package — this is the only join table backed by a custom struct, so this one call covers it.

## Verification

Ran `AutoMigrate` over `DatabaseModels` through the patched `SetupDatabase`:

- Fresh database: `calendar_calendar_events` is created with `featured`, `members_only`, and `tier_ids_only`.
- Database that already has the columns (dev/prod situation): migration is a no-op, existing rows untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)